### PR TITLE
空のArrayを取り除く

### DIFF
--- a/crawl.rb
+++ b/crawl.rb
@@ -58,5 +58,5 @@ end
 toml_string = $stdin.read
 feeds = TomlRB.parse(toml_string, symbolize_keys: true)
 
-entries = feeds.map {|username, feed| Crawler.new(feed[:feed_url]).crawl }.flatten.map(&:to_h)
+entries = feeds.map {|username, feed| Crawler.new(feed[:feed_url]).crawl }.flatten.map(&:to_h).select {|a| !a.empty?}
 puts({entries: entries}.to_json)

--- a/crawl.rb
+++ b/crawl.rb
@@ -58,5 +58,5 @@ end
 toml_string = $stdin.read
 feeds = TomlRB.parse(toml_string, symbolize_keys: true)
 
-entries = feeds.map {|username, feed| Crawler.new(feed[:feed_url]).crawl }.flatten.map(&:to_h).select {|a| !a.empty?}
+entries = feeds.map {|username, feed| Crawler.new(feed[:feed_url]).crawl }.reject(&:nil?).flatten.map(&:to_h)
 puts({entries: entries}.to_json)


### PR DESCRIPTION
## WHAT
`crawl.rb` にてフィードが200系以外のレスポンスを返したとき，空のArrayが記事一覧に含まれていのでこれを取り除く．

## WHY
 `generate.rb` が落ちるから．
cf. #11

---

closes #11