### PR TITLE
フィードが必要項目を含んでいるかの確認

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: ruby:2.6
+        environment:
+          - LANG: C.UTF-8
+
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-{{ checksum "Gemfile.lock" }}
+      - run:
+          command: bundle install --path vendor/bundle
+      - save_cache:
+          key: dependency-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      - run:
+          command: |
+            cat feeds.toml | bundle exec ruby ./crawl.rb | bundle exec ruby ./generate.rb > /dev/null

--- a/generate.rb
+++ b/generate.rb
@@ -3,6 +3,7 @@ require 'nokogiri'
 require 'fileutils'
 require 'json'
 require 'time'
+require 'pp'
 
 module View
   class Entry < Struct.new(:entry_url, :title, :abstract_html, :icon_url, :published_at)
@@ -38,6 +39,13 @@ ENTRY_COUNT = 50.freeze
 
 entries_json_string = STDIN.read
 entries = JSON.parse(entries_json_string)['entries'].map do |e|
+  %w(entry_url title abstract).each do |k|
+    if e[k].nil?
+      STDERR.puts "#{k}がありません:"
+      STDERR.puts "#{e.pretty_inspect}"
+      exit(status=1)
+    end
+  end
   View::Entry.new(
     e['entry_url'],
     e['title'],

--- a/generate.rb
+++ b/generate.rb
@@ -7,16 +7,26 @@ require 'pp'
 
 module View
   class Entry < Struct.new(:entry_url, :title, :abstract_html, :icon_url, :published_at)
-    def initialize(*args)
-      {'entry_url': 0,  'title': 1, 'abstract_html': 2, 'published_at': 4}.each do |k, v|
-        if args[v].nil?
-          STDERR.puts "#{k}がありません:"
-          raise ArgumentError
-        end
+    def initialize(entry_url, title, abstract_html, icon_url, published_at)
+      if entry_url.nil?
+        STDERR.puts 'entry_urlがありません:'
+        raise ArgumentError
       end
-      args[4] = Time.parse(args[4])
-      super(*args)
+      if title.nil?
+        STDERR.puts 'titleがありません:'
+        raise ArgumentError
+      end
+      if abstract_html.nil?
+        STDERR.puts 'abstract_htmlがありません:'
+        raise ArgumentError
+      end
+      if published_at.nil?
+        STDERR.puts 'published_atがありません:'
+        raise ArgumentError
+      end
+      super(entry_url, title, abstract_html, icon_url, Time.parse(published_at))
     end
+
     def abstract
       Nokogiri::HTML(self.abstract_html).text
     end


### PR DESCRIPTION
## WHAT
必要な項目が欠けているフィードがある際に `feeds.json` の生成を明示的に停止，エラーを報告する．
また，各フィードが必要項目を持っているかCIで検証する．

## WHY
masterに取り込んで `feeds.json` の生成がコケる前に，おかしなフィードを検出したい．