### PR TITLE
READMEの説明を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@
 
 ### Create feeds.toml
 
-`crawler/feeds.toml` を作成し，ブログフィードを登録する．
-
-```
-$ vim crawler/feeds.toml
-```
-
 `feeds.toml` の例：
 
 ```feeds.toml
@@ -25,6 +19,7 @@ feed_url = "https://dawn.hateblo.jp/rss"
 ### Build json
 
 ```
+$ bundle install --path vendor/bundle
 $ cat feeds.toml | bundle exec ruby crawl.rb | bundle exec ruby generate.rb > dist/feeds.json
 ```
 


### PR DESCRIPTION
- 昔のディレクトリ構造を引きずっている説明があった
  - そもそも`feeds.toml`のファイルパスを書く必要がないので説明を消した
- `bundle install`が抜けていたので修正