### PR TITLE
Dockerfileの追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.6-alpine
+
+WORKDIR /apps
+
+
+RUN apk add --no-cache build-base libxml2-dev libxslt-dev
+
+COPY ./Gemfile ./Gemfile.lock ./
+
+COPY ./crawl.rb ./generate.rb ./
+
+RUN bundle install --path vendor/bundle
+
+CMD ["sh", "-c", "cat feeds.toml | bundle exec ruby crawl.rb | bundle exec ruby generate.rb > dist/feeds.json"]

--- a/README.md
+++ b/README.md
@@ -17,9 +17,16 @@ feed_url = "https://dawn.hateblo.jp/rss"
 ```
 
 ### Build json
-
+#### Locally
 ```
 $ bundle install --path vendor/bundle
 $ cat feeds.toml | bundle exec ruby crawl.rb | bundle exec ruby generate.rb > dist/feeds.json
 ```
 
+#### With [docker image](https://cloud.docker.com/u/camphor/repository/docker/camphor/feeds)
+```
+$ docker run \
+    -v $PWD/feeds.toml:/apps/feeds.toml:ro \
+    -v $PWD/dist:/apps/dist \
+    camphor/feeds:latest
+```


### PR DESCRIPTION
## WHAT
Dockerfileを追加し，ビルド済みイメージを公開する．また，更新時にビルド済みイメージを取ってくることで高速化する．

[Docker Hub](https://cloud.docker.com/u/camphor/repository/docker/camphor/feeds) にイメージを公開し，自動ビルドを有効にしました．Rundeckで `feeds.json` 再生成するときはこちらのイメージを用いるように変更します．
イメージは masterをビルドしたものにlatestタグが，gitのリリース (例: `v0.1.0`) をビルドしたものにそのバージョンのタグが付きます．

## WHY
- Rundeckで `ruby:2.6-alpine` から出発して環境構築・ビルドするのを回避することで更新間隔を短くする
- `feeds.toml` の管理とfeedsのソースコードの管理を将来的に分けることに備える

## TODO
- [ ] 本PRmerge後，masterに対して `v0.1.0` のリリースを作成する
- [ ] Rundeckの設定を変更し，イメージを使用する
