### PR TITLE
Qiitaが生成するAtomフィードに対応する

### DIFF
--- a/crawl.rb
+++ b/crawl.rb
@@ -44,7 +44,7 @@ class Crawler
         Entry.new(
           item.link.href,
           item.title.content,
-          item.content.content,
+          item.summary&.content || item.content.content,
           item.links.find { |link| link.rel == 'enclosure' }&.href,
           item.published.content
         )

--- a/crawl.rb
+++ b/crawl.rb
@@ -26,7 +26,7 @@ class Crawler
       return
     end
 
-    feed = RSS::Parser.parse(response.body)
+    feed = RSS::Parser.parse(response.body, false)
 
     case feed
     when RSS::Rss
@@ -44,7 +44,7 @@ class Crawler
         Entry.new(
           item.link.href,
           item.title.content,
-          item.summary.content,
+          item.content.content,
           item.links.find { |link| link.rel == 'enclosure' }&.href,
           item.published.content
         )


### PR DESCRIPTION
## WHAT

Qiitaが生成するAtomフィードもfeeds.tomlに入れられるようにする．

具体的には以下の2つを行う

- RSSフィードのパーサーのvalidationをスキップする
- `summary`が存在しない場合に`content`を見に行く

## WHY

Qiitaは，Atomフィードを生成する機能を持っており，ユーザーの投稿一覧を取得することができる．
例： [https://qiita.com/genya0407/feed](https://qiita.com/genya0407/feed)

このフィードをfeeds.tomlに登録できたら嬉しいが，以下のような問題があるため，それぞれを解決する変更を入れたい．

### Qiitaが生成するAtomフィードはinvalidなAtomフィードである

QiitaのAtomフィードには`href`属性を持たない`link`タグが存在している．
Atomの仕様上は，全ての`link`タグは`href`属性を持つ必要があるため，QiitaのAtomフィードはinvalidである．
(See: https://www.futomi.com/lecture/japanese/rfc4287.html#s4_2_7)

RubyのRSSパッケージのパーサーは，デフォルトでフィードのvalidationを行うため，現状では`crawl.rb`の実行がコケる．
これを解決するために，パーサーのvalidationをスキップする．

### Qiitaが生成するAtomフィードには`summary`が含まれない

Qiitaが生成するAtomフィードには`summary`が含まれない．
Atomの仕様上，`summary`は必須項目ではないので，これはQiita特有の問題ではない．
(See: https://www.futomi.com/lecture/japanese/rfc4287.html#s4_1_1)

これを解決するために，`summary`がない場合は`content`にフォールバックするようにする．

※ Atomの仕様上は`content`も必須項目ではないことに注意
