### PR TITLE
bundlerのバージョンを上げた

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,4 +31,4 @@ DEPENDENCIES
   toml-rb
 
 BUNDLED WITH
-   1.17.0.pre.2
+   2.0.1


### PR DESCRIPTION
## What

bundlerのバージョンを1.17から2.0に上げた．

## Why

Ruby 2.6.2で`gem install bundler`をするとbundler 2.0が入る．
Ruby 2.6.2に同梱されるデフォルトのbundlerのバージョンは1.17.2らしい(参考：https://qiita.com/takaram/items/084eaa5005bcca2ae6e9#%E3%81%95%E3%81%84%E3%81%94%E3%81%AB)．

bundler 1で生成された`Gemfile.lock`と，bundler 2.0で生成された`Gemfile.lock`には互換性がない．
というか，違うメジャーバージョンが記載された`Gemfile.lock`を読むとエラーを吐いて落ちるようになってるっぽい(マイナーバージョンは違っても大丈夫そう)．

@genya0407 が `gem install bundler` をしたところbundler 2.0が入ってしまったため，`bundle update --bundler`によって`Gemfile.lock`を更新した．

## この変更を取り込むと何が起きるか

この変更を取り込むと，僕以外の人々が`bundle install`できなくなる(`gem install bundler`すれば解決する)．
しかし将来的にはバージョンを上げておくことが必要なので，一応PRを作りました．