### PR TITLE
dora1998の登録フィードを変更

### DIFF
--- a/feeds.toml
+++ b/feeds.toml
@@ -8,7 +8,7 @@ feed_url = "https://tech.camph.net/feed/"
 feed_url = "https://blog.tomoyat1.com/rss"
 
 [dora1998]
-feed_url = "http://dorapocket.starfree.jp/feed/"
+feed_url = "https://feed-api.minoru.dev/rss"
 
 [marty954]
 feed_url = "http://skstmrty.hatenablog.com/feed"


### PR DESCRIPTION
# WHAT
QiitaとWordPressを統合したフィードの配信ができるようになったので、そちらのフィードを見に行くように変更した。