### PR TITLE
RSS 1.0に対応

### DIFF
--- a/crawl.rb
+++ b/crawl.rb
@@ -49,6 +49,16 @@ class Crawler
           item.published.content
         )
       end
+    when RSS::RDF
+      feed.items.map do |item|
+        Entry.new(
+          item.link,
+          item.title,
+          item.description,
+          item.channel.image&.resource,
+          item.date
+        )
+      end
     else
       puts "Unsupported feed type: #{feed.class} from #{@feed_url}"
     end

--- a/crawl.rb
+++ b/crawl.rb
@@ -55,7 +55,7 @@ class Crawler
           item.link,
           item.title,
           item.description,
-          item.channel.image&.resource,
+          item.channel.image&.resource, # NOTE: 画像付きのRSS1.0のフィードを見つけられなかったので動作未検証
           item.date
         )
       end

--- a/crawl.rb
+++ b/crawl.rb
@@ -55,7 +55,7 @@ class Crawler
           item.link,
           item.title,
           item.description,
-          item.channel.image&.resource, # NOTE: 画像付きのRSS1.0のフィードを見つけられなかったので動作未検証
+          feed.channel.image&.resource, # NOTE: 画像付きのRSS1.0のフィードを見つけられなかったので動作未検証
           item.date
         )
       end


### PR DESCRIPTION
## WHAT

RSS 1.0のフィードも読めるようにした。

https://docs.ruby-lang.org/ja/latest/library/rss.html

## NOTICE

アイコン画像付きのRSS 1.0のフィードを見つけられなかったため、 `icon_url` が正しく扱われるのかは未検証です。