### PR TITLE
abstractがnilであるようなエントリを許容する

### DIFF
--- a/feeds_me.toml
+++ b/feeds_me.toml
@@ -1,2 +1,0 @@
-[dena_design_blog]
-feed_url = "https://design.dena.com/feed.xml"

--- a/feeds_me.toml
+++ b/feeds_me.toml
@@ -1,0 +1,2 @@
+[dena_design_blog]
+feed_url = "https://design.dena.com/feed.xml"

--- a/generate.rb
+++ b/generate.rb
@@ -16,10 +16,6 @@ module View
         STDERR.puts 'titleがありません:'
         raise ArgumentError
       end
-      if abstract_html.nil?
-        STDERR.puts 'abstract_htmlがありません:'
-        raise ArgumentError
-      end
       if published_at.nil?
         STDERR.puts 'published_atがありません:'
         raise ArgumentError
@@ -28,7 +24,9 @@ module View
     end
 
     def abstract
-      Nokogiri::HTML(self.abstract_html).text
+      unless self.abstract_html.nil?
+        Nokogiri::HTML(self.abstract_html).text
+      end
     end
 
     alias :old_published_at :published_at


### PR DESCRIPTION
## WHAT

- `abstract_html` がnilであるようなエントリが `generate.rb` に入力された時、バリデーションで落とさない
- `abstract_html` がnilである場合、 `abstract`もnilにする

## WHY

- 少なくともAtomにおいては、`summary`要素も`content`要素も必須ではないので、これらがnilになるようなフィードもvalidである。
  - (参考： https://www.futomi.com/lecture/japanese/rfc4287.html#s4_1_2 )
- camph.net以外で個人的にfeedsを使っていて、そっちで`summary`も`content`もないフィードを取り扱いたいという気持ちがあります。