### PR TITLE
9期で卒業するメンバーのブログを削除

### DIFF
--- a/feeds.toml
+++ b/feeds.toml
@@ -13,9 +13,6 @@ feed_url = "https://blog.tomoyat1.com/rss"
 [dora1998]
 feed_url = "https://feed-api.minoru.dev/rss"
 
-[marty954]
-feed_url = "http://skstmrty.hatenablog.com/feed"
-
 [KMConner]
 feed_url = "https://blog.kmconner.net/rss"
 

--- a/feeds.toml
+++ b/feeds.toml
@@ -7,9 +7,6 @@ feed_url = "https://tech.camph.net/feed/"
 [camphor-blog]
 feed_url = "https://blog.camph.net/feed/"
 
-[tomoyat1]
-feed_url = "https://blog.tomoyat1.com/rss"
-
 [dora1998]
 feed_url = "https://feed-api.minoru.dev/rss"
 


### PR DESCRIPTION
## Why
[10期移行issue](https://github.com/camphor-/tasks/issues/1375) に伴い、9期で卒業するメンバーのブログを削除する必要がある。

## What

- martyさんのブログを削除
