### PR TITLE
Build and Sync with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build and Push to registry
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: registry.camph.net
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: registry.camph.net/feeds:latest
+      - name: Notify to Slack
+        uses: craftech-io/slack-action@v1
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and Push to registry
 
 on:
   push:
-    branches: [master]
+    # branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and Push to registry
 
 on:
   push:
-    # branches: [master]
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@ name: Sync
 
 on:
   push:
-    branches: [master]
+    # branches: [master]
 
 jobs:
   sync:
@@ -25,8 +25,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Build feeds.json
         run: |
-          docker pull registry.camph.net/feeds:v0.1.0
-          docker run --rm -v $PWD/feeds.toml:/apps/feeds.toml:ro -v $PWD/dist:/apps/dist registry.camph.net/feeds:v0.1.0
+          docker pull registry.camph.net/feeds:latest
+          docker run --rm -v $PWD/feeds.toml:/apps/feeds.toml:ro -v $PWD/dist:/apps/dist registry.camph.net/feeds:latest
       - name: rsync feeds.json
         run: rsync $PWD/dist/feeds.json -e "ssh -p ${{ secrets.KONOE_SSH_PORT }}" ${{ secrets.KONOE_SSH_USERNAME }}@${{ secrets.KONOE_SSH_HOST }}:/home/deploy/feeds/www/public/feeds.json
       - name: Notify to Slack

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@ name: Sync
 
 on:
   push:
-    branches: [master]
+    # branches: [master]
 
 jobs:
   sync:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Sync
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  sync:
+    name: Sync feeds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.KONOE_SSH_KEY }}
+          name: id_rsa
+          known_hosts: ${{ secrets.KONOE_KNOWN_HOSTS }}
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: registry.camph.net
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Build feeds.json
+        run: |
+          docker pull registry.camph.net/feeds:v0.1.0
+          docker run --rm -v $PWD/feeds.toml:/apps/feeds.toml:ro -v $PWD/dist:/apps/dist registry.camph.net/feeds:v0.1.0
+      - name: rsync feeds.json
+        run: rsync $PWD/dist/feeds.json -e "ssh -p ${{ secrets.KONOE_SSH_PORT }}" ${{ secrets.KONOE_SSH_USERNAME }}@${{ secrets.KONOE_SSH_HOST }}:/home/deploy/feeds/www/public/feeds.json
+      - name: Notify to Slack
+        uses: craftech-io/slack-action@v1
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,8 +1,8 @@
 name: Sync
 
 on:
-  push:
-    # branches: [master]
+  schedule:
+    - cron: "0 15 * 11,12 *" # 00:00 JST in November and December (15:00 UTC)
 
 jobs:
   sync:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@ name: Sync
 
 on:
   push:
-    # branches: [master]
+    branches: [master]
 
 jobs:
   sync:

--- a/feeds.toml
+++ b/feeds.toml
@@ -13,6 +13,9 @@ feed_url = "https://feed-api.minoru.dev/rss"
 [KMConner]
 feed_url = "https://blog.kmconner.net/rss"
 
+[atrn0]
+feed_url = "https://atrn0.github.io/index.xml"
+
 [p1ass]
 feed_url = "https://blog-api.p1ass.com/rss"
 

--- a/feeds.toml
+++ b/feeds.toml
@@ -13,9 +13,6 @@ feed_url = "https://feed-api.minoru.dev/rss"
 [KMConner]
 feed_url = "https://blog.kmconner.net/rss"
 
-[atrn0]
-feed_url = "https://atrn0.github.io/index.xml"
-
 [p1ass]
 feed_url = "https://blog-api.p1ass.com/rss"
 


### PR DESCRIPTION
Rundeckを廃止してGitHub ActionsへJobを移行することになったので、sync、imageのビルド、pushをGitHub Actionsで行う。